### PR TITLE
Add generics for result data

### DIFF
--- a/src/results/EndResult.ts
+++ b/src/results/EndResult.ts
@@ -1,9 +1,9 @@
 import express from 'express'
 import { BaseResult } from './BaseResult'
 
-export class EndResult extends BaseResult {
+export class EndResult<D> extends BaseResult {
   constructor(
-    public readonly data: any,
+    public readonly data: D,
     public readonly encoding?: string,
     public readonly status: number = 200
   ) {

--- a/src/results/JSONResult.ts
+++ b/src/results/JSONResult.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import { BaseResult } from './BaseResult'
 
-export class JSONResult extends BaseResult {
-  constructor(public readonly data: any, public readonly status: number = 200) {
+export class JSONResult<D> extends BaseResult {
+  constructor(public readonly data: D, public readonly status: number = 200) {
     super()
   }
 

--- a/src/results/NextResult.ts
+++ b/src/results/NextResult.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import { BaseResult } from './BaseResult'
 
-export class NextResult extends BaseResult {
-  constructor(public readonly error?: any) {
+export class NextResult<E> extends BaseResult {
+  constructor(public readonly error?: E) {
     super()
   }
 

--- a/src/results/RenderResult.ts
+++ b/src/results/RenderResult.ts
@@ -9,10 +9,10 @@ export type RenderResultCallback = (
   next: express.NextFunction
 ) => void
 
-export class RenderResult extends BaseResult {
+export class RenderResult<L> extends BaseResult {
   constructor(
     public readonly view: string,
-    public readonly locals?: any,
+    public readonly locals?: L,
     public readonly callback?: RenderResultCallback,
     public readonly status: number = 200
   ) {

--- a/src/results/SendResult.ts
+++ b/src/results/SendResult.ts
@@ -1,8 +1,8 @@
 import express from 'express'
 import { BaseResult } from './BaseResult'
 
-export class SendResult extends BaseResult {
-  constructor(public readonly data: any, public readonly status: number = 200) {
+export class SendResult<D> extends BaseResult {
+  constructor(public readonly data: D, public readonly status: number = 200) {
     super()
   }
 

--- a/src/specs/results/EndResult.spec.ts
+++ b/src/specs/results/EndResult.spec.ts
@@ -7,7 +7,7 @@ describe('EndResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): EndResult<string> {
         return new EndResult('Hello')
       }
     }
@@ -30,7 +30,7 @@ describe('EndResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): EndResult<string> {
         return new EndResult('Hello', 'ascii')
       }
     }
@@ -55,7 +55,7 @@ describe('EndResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): EndResult<string> {
         return new EndResult('Hello', undefined, 201)
       }
     }

--- a/src/specs/results/JSONResult.spec.ts
+++ b/src/specs/results/JSONResult.spec.ts
@@ -4,10 +4,13 @@ import request from 'supertest'
 describe('JSONResult', () => {
   it('uses res.json', async () => {
     // Given
+    interface IndexResponseData {
+      message: string
+    }
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): JSONResult<IndexResponseData> {
         return new JSONResult({
           message: 'Hello'
         })
@@ -33,10 +36,13 @@ describe('JSONResult', () => {
 
   it('accepts status', async () => {
     // Given
+    interface IndexResponseData {
+      message: string
+    }
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): JSONResult<IndexResponseData> {
         return new JSONResult(
           {
             message: 'Hello'

--- a/src/specs/results/NextResult.spec.ts
+++ b/src/specs/results/NextResult.spec.ts
@@ -36,7 +36,7 @@ describe('NextResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): NextResult<Error> {
         return new NextResult(new Error('Hello'))
       }
     }

--- a/src/specs/results/RenderResult.spec.ts
+++ b/src/specs/results/RenderResult.spec.ts
@@ -39,10 +39,13 @@ describe('RenderResult', () => {
 
   it('accepts data', async () => {
     // Given
+    interface IndexRenderLocals {
+      message: string
+    }
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): RenderResult<IndexRenderLocals> {
         return new RenderResult('test', { message: 'test' })
       }
     }

--- a/src/specs/results/SendResult.spec.ts
+++ b/src/specs/results/SendResult.spec.ts
@@ -7,7 +7,7 @@ describe('SendResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): SendResult<string> {
         return new SendResult('Hello')
       }
     }
@@ -30,7 +30,7 @@ describe('SendResult', () => {
     @controller('/')
     class HomeController {
       @httpGet('/')
-      index() {
+      index(): SendResult<string> {
         return new SendResult('Hello', 201)
       }
     }


### PR DESCRIPTION
Now, some results have a generic type to check return type of controller methods.

```ts
    interface IndexResponseData {
      message: string
    }
    @controller('/')
    class HomeController {
      @httpGet('/')
      // Now we definitely have to return `JSONResult` with `IndexResponseData`
      index(): JSONResult<IndexResponseData> {
        return new JSONResult({
          message: 'Hello'
        })
      }
    }
```