### PR TITLE
Features/base controller context

### DIFF
--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -16,11 +16,55 @@ interface HttpContext {
   res: express.Response
 }
 
-export class BaseController {
-  httpContext?: HttpContext
-  injector: (type: string) => any
+interface Context {
+  req: express.Request
+  res: express.Response
+  inject<S>(type: string): S
+}
 
+export class BaseController {
+  context?: Context
+
+  /* istanbul ignore next */
+  get httpContext(): HttpContext | undefined {
+    // tslint:disable-next-line:no-console
+    console.warn(
+      'BaseController#httpContext will be deprecated from v1.0.0. Please use BaseController#context.'
+    )
+    if (this.context == null) return
+    return {
+      req: this.context.req,
+      res: this.context.res
+    }
+  }
+
+  /* istanbul ignore next */
+  get injector(): ((type: string) => any) | undefined {
+    // tslint:disable-next-line:no-console
+    console.warn(
+      'BaseController#injector will be deprecated from v1.0.0. Please use BaseController#context.inject.'
+    )
+    if (this.context == null) return
+    return this.context.inject
+  }
+
+  /* istanbul ignore next */
+  set injector(injector: ((type: string) => any) | undefined) {
+    // tslint:disable-next-line:no-console
+    console.warn(
+      'BaseController#injector will be deprecated from v1.0.0. Please use BaseController#context.inject.'
+    )
+    if (this.context != null && injector != null) {
+      this.context.inject = injector
+    }
+  }
+
+  /* istanbul ignore next */
   inject<S>(type: string): S {
+    // tslint:disable-next-line:no-console
+    console.warn(
+      'BaseController#inject will be deprecated from v1.0.0. Please use BaseController#context.inject.'
+    )
     if (this.injector == null) throw new Error('Injector is not set.')
     return this.injector(type)
   }

--- a/src/BaseController.ts
+++ b/src/BaseController.ts
@@ -19,7 +19,7 @@ interface HttpContext {
 interface Context {
   req: express.Request
   res: express.Response
-  inject<S>(type: string): S
+  inject<S>(key: string): S
 }
 
 export class BaseController {
@@ -39,7 +39,7 @@ export class BaseController {
   }
 
   /* istanbul ignore next */
-  get injector(): ((type: string) => any) | undefined {
+  get injector(): ((key: string) => any) | undefined {
     // tslint:disable-next-line:no-console
     console.warn(
       'BaseController#injector will be deprecated from v1.0.0. Please use BaseController#context.inject.'
@@ -49,7 +49,7 @@ export class BaseController {
   }
 
   /* istanbul ignore next */
-  set injector(injector: ((type: string) => any) | undefined) {
+  set injector(injector: ((key: string) => any) | undefined) {
     // tslint:disable-next-line:no-console
     console.warn(
       'BaseController#injector will be deprecated from v1.0.0. Please use BaseController#context.inject.'
@@ -60,13 +60,13 @@ export class BaseController {
   }
 
   /* istanbul ignore next */
-  inject<S>(type: string): S {
+  inject<S>(key: string): S {
     // tslint:disable-next-line:no-console
     console.warn(
       'BaseController#inject will be deprecated from v1.0.0. Please use BaseController#context.inject.'
     )
     if (this.injector == null) throw new Error('Injector is not set.')
-    return this.injector(type)
+    return this.injector(key)
   }
 
   end(data: any, encoding?: string, status?: number) {

--- a/src/specs/tachijs.spec.ts
+++ b/src/specs/tachijs.spec.ts
@@ -206,13 +206,13 @@ describe('tachijs', () => {
     })
   })
 
-  it('exposes httpContext if controller is extended from BaseController', async () => {
+  it('exposes context if controller is extended from BaseController', async () => {
     // Given
     @controller('/')
     class HomeController extends BaseController {
       @httpGet('/')
       index() {
-        return this.httpContext!.req.query.message
+        return this.context!.req.query.message
       }
     }
     const app = tachijs({

--- a/src/tachijs.ts
+++ b/src/tachijs.ts
@@ -111,10 +111,10 @@ class TachiJSApp {
           controller.context = {
             req,
             res,
-            inject: (type: string) => {
-              if (!this.containerMap.has(type))
-                throw new Error(`No service is registered for "${type}" key.`)
-              return this.instantiate(this.containerMap.get(type))
+            inject: (key: string) => {
+              if (!this.containerMap.has(key))
+                throw new Error(`No service is registered for "${key}" key.`)
+              return this.instantiate(this.containerMap.get(key))
             }
           }
         }

--- a/src/tachijs.ts
+++ b/src/tachijs.ts
@@ -108,14 +108,14 @@ class TachiJSApp {
       try {
         const controller = this.instantiate(ControllerConstructor)
         if (controller instanceof BaseController) {
-          controller.httpContext = {
+          controller.context = {
             req,
-            res
-          }
-          controller.injector = (type: string) => {
-            if (!this.containerMap.has(type))
-              throw new Error(`No service is registered for "${type}" key.`)
-            return this.instantiate(this.containerMap.get(type))
+            res,
+            inject: (type: string) => {
+              if (!this.containerMap.has(type))
+                throw new Error(`No service is registered for "${type}" key.`)
+              return this.instantiate(this.containerMap.get(type))
+            }
           }
         }
         const method = controller[methodMeta.propertyKey]


### PR DESCRIPTION
`BaseController#context` has been implemented.
```ts
interface Context {
  req: express.Request
  res: express.Response
  inject<S>(key: string): S
}

export class BaseController {
  context?: Context
}
```

So `BaseController#httpContext`, `BaseController#inject` and `BaseController#injector` will be deprecated from v1.0.0.