### PR TITLE
Features/injector

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -546,7 +546,7 @@ export class RedirectResult extends BaseResult {
 }
 ```
 
-### Dependency injection
+#### Dependency injection
 
 To make controllers more testable, tachijs provides dependency injection.
 
@@ -670,6 +670,43 @@ class NotificationService {
     await this.mailer.sendEmail('Welcome!')
   }
 }
+```
+
+##### DI without `tachijs`
+
+When some testing or just writing scripts using services, you might want to use DI without `tachijs` function.
+So we exposed `Injector` class which is used by `tachijs`.
+
+```ts
+enum ServiceTypes {
+  NameService = 'NameService',
+  MyService = 'MyService'
+}
+class NameService {
+  getName() {
+    return 'Test'
+  }
+}
+class MyService {
+  constructor(
+    @inject(ServiceTypes.NameService) private nameService: NameService
+  ) {}
+
+  sayHello() {
+    return `Hello, ${this.nameService.getName()}`
+  }
+}
+const container = {
+  [ServiceTypes.NameService]: NameService,
+  [ServiceTypes.MyService]: MyService
+}
+// Create injector
+const injector = new Injector(container)
+
+// Instantiate by a key
+const myService = injector.inject<MyService>(ServiceTypes.MyService)
+// Instantiate by a constructor
+const myService = injector.instantiate(MyService)
 ```
 
 ### Bad practices
@@ -964,6 +1001,20 @@ tachijs will finalize response with `res.sendStatus(status)`.
 ### `@inject(key: string)`
 
 Inject a registered service in container by the given `key`.
+
+### `class Injector`
+
+#### `new Injector<C>(container: C)`
+
+Instantiate an injector with container
+
+#### `#instantiate(Constructor: any): any`
+
+Instantiate a service constructor. If the constructor has injected services, this method instantiate and inject them by `#inject` method.
+
+#### `#inject<S = any>(key: string): S`
+
+Instantiate a service by a key from Container. If there is no service for the given key, it will throws an error.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -700,6 +700,7 @@ const container = {
   [ServiceTypes.NameService]: NameService,
   [ServiceTypes.MyService]: MyService
 }
+
 // Create injector
 const injector = new Injector(container)
 

--- a/src/Injector.ts
+++ b/src/Injector.ts
@@ -1,0 +1,29 @@
+import { getInjectMetaList } from './decorators'
+
+export class Injector<C> {
+  private readonly containerMap: Map<string, any>
+  constructor(container: C) {
+    this.containerMap = new Map(Object.entries(container))
+  }
+
+  instantiate(Constructor: any): any {
+    const injectMetaList = getInjectMetaList(Constructor)
+    const args = injectMetaList.map(injectMeta => {
+      try {
+        return this.inject(injectMeta.key)
+      } catch (error) {
+        throw new Error(
+          `${error.message} (While instantiating "${Constructor.name}")`
+        )
+      }
+    })
+
+    return new Constructor(...args)
+  }
+
+  inject<S = any>(key: string): S {
+    if (!this.containerMap.has(key))
+      throw new Error(`No service is registered for "${key}" key.`)
+    return this.instantiate(this.containerMap.get(key))
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,6 @@ export * from './tachijs'
 export * from './decorators'
 export * from './results'
 export * from './BaseController'
+export * from './Injector'
 
 export default tachijs

--- a/src/specs/Injector.spec.ts
+++ b/src/specs/Injector.spec.ts
@@ -1,0 +1,124 @@
+import { inject, Injector } from '../index'
+
+describe('Injector', () => {
+  describe('#instantiate', () => {
+    it('instantiates a Constructor', async () => {
+      // Given
+      enum ServiceTypes {
+        NameService = 'NameService'
+      }
+      class NameService {
+        getName() {
+          return 'Test'
+        }
+      }
+      class MyService {
+        constructor(
+          @inject(ServiceTypes.NameService) private nameService: NameService
+        ) {}
+
+        sayHello() {
+          return `Hello, ${this.nameService.getName()}`
+        }
+      }
+      const container = {
+        [ServiceTypes.NameService]: NameService
+      }
+      const injector = new Injector(container)
+
+      // When
+      const myService = injector.instantiate(MyService)
+      const result = myService.sayHello()
+
+      // Then
+      expect(myService).toBeInstanceOf(MyService)
+      expect(result).toBe('Hello, Test')
+    })
+
+    it('throws if injected service does not exist.', async () => {
+      // Given
+      enum ServiceTypes {
+        NameService = 'NameService'
+      }
+      class NameService {
+        getName() {
+          return 'Test'
+        }
+      }
+      class MyService {
+        constructor(
+          @inject(ServiceTypes.NameService) private nameService: NameService
+        ) {}
+
+        sayHello() {
+          return `Hello, ${this.nameService.getName()}`
+        }
+      }
+      const container = {}
+      const injector = new Injector(container)
+      expect.assertions(1)
+
+      // When
+      try {
+        injector.instantiate(MyService)
+      } catch (error) {
+        // Then
+        expect(error).toMatchObject({
+          message:
+            'No service is registered for "NameService" key. (While instantiating "MyService")'
+        })
+      }
+    })
+  })
+
+  describe('#inject', async () => {
+    it('instantiates a constructor by the given key from container', () => {
+      // Given
+      enum ServiceTypes {
+        MyService = 'MyService'
+      }
+      class MyService {
+        sayHello() {
+          return 'Hello'
+        }
+      }
+      const container = {
+        [ServiceTypes.MyService]: MyService
+      }
+      const injector = new Injector(container)
+
+      // When
+      const myService = injector.inject(ServiceTypes.MyService)
+
+      // Then
+      expect(myService).toBeInstanceOf(MyService)
+    })
+    it('throws if no service is regisered to container for the given key', () => {
+      // Given
+      enum ServiceTypes {
+        MyService = 'MyService',
+        UnregisteredService = 'UnregisteredService'
+      }
+      class MyService {
+        sayHello() {
+          return 'Hello'
+        }
+      }
+      const container = {
+        [ServiceTypes.MyService]: MyService
+      }
+      const injector = new Injector(container)
+      expect.assertions(1)
+
+      try {
+        // When
+        injector.inject(ServiceTypes.UnregisteredService)
+      } catch (error) {
+        // Then
+        expect(error).toMatchObject({
+          message: 'No service is registered for "UnregisteredService" key.'
+        })
+      }
+    })
+  })
+})

--- a/src/specs/tachijs.spec.ts
+++ b/src/specs/tachijs.spec.ts
@@ -201,7 +201,7 @@ describe('tachijs', () => {
       status: 500,
       text: JSON.stringify({
         message:
-          'The constructor for "MyService" is not registered in the current container.'
+          'No service is registered for "MyService" key. (While instantiating "HomeController")'
       })
     })
   })


### PR DESCRIPTION
Expose Injector so DI can be used without tachijs

```ts
enum ServiceTypes {
  NameService = 'NameService',
  MyService = 'MyService'
}
class NameService {
  getName() {
    return 'Test'
  }
}
class MyService {
  constructor(
    @inject(ServiceTypes.NameService) private nameService: NameService
  ) {}

  sayHello() {
    return `Hello, ${this.nameService.getName()}`
  }
}
const container = {
  [ServiceTypes.NameService]: NameService,
  [ServiceTypes.MyService]: MyService
}

// Create injector
const injector = new Injector(container)

// Instantiate by a key
const myService = injector.inject<MyService>(ServiceTypes.MyService)
// Instantiate by a constructor
const myService = injector.instantiate(MyService)
```