### PR TITLE
Corrected registering order in httpMethods - added tests for registra…

### DIFF
--- a/src/decorators/httpMethod.ts
+++ b/src/decorators/httpMethod.ts
@@ -38,13 +38,13 @@ export function httpMethod(
     const previousHttpMethodList = getHttpMethodMetaList(target.constructor)
 
     const newHttpMethodList = [
+      ...previousHttpMethodList,
       {
         method,
         path,
         propertyKey,
         middlewares
-      },
-      ...previousHttpMethodList
+      }
     ]
 
     setHttpMethodMetaList(target.constructor, newHttpMethodList)

--- a/src/specs/decorators/httpMethod.spec.ts
+++ b/src/specs/decorators/httpMethod.spec.ts
@@ -254,13 +254,14 @@ describe('httpMethod', () => {
     // Given
     @controller('/')
     class HomeController {
-      @httpMethod('get', '/test/new')
+      @httpMethod('get', '/')
       index() {
         return 'Hello'
       }
-      @httpMethod('get', '/test/:id')
-      indexWithId() {
-        return 'Hello-id'
+
+      @httpMethod('get', '/')
+      secondIndex() {
+        return 'Hello Second'
       }
     }
     const app = tachijs({
@@ -268,16 +269,12 @@ describe('httpMethod', () => {
     })
 
     // When
-    const response = await request(app).get('/test/new')
-    const response_id = await request(app).get('/test/23')
+    const response = await request(app).get('/')
+
     // Then
     expect(response).toMatchObject({
       status: 200,
       text: 'Hello'
-    })
-    expect(response_id).toMatchObject({
-      status: 200,
-      text: 'Hello-id'
     })
   })
 })

--- a/src/specs/decorators/httpMethod.spec.ts
+++ b/src/specs/decorators/httpMethod.spec.ts
@@ -249,6 +249,37 @@ describe('httpMethod', () => {
     })
     expect(spy).toBeCalled()
   })
+
+  it('registers routes from top to bottom', async () => {
+    // Given
+    @controller('/')
+    class HomeController {
+      @httpMethod('get', '/test/new')
+      index() {
+        return 'Hello'
+      }
+      @httpMethod('get', '/test/:id')
+      indexWithId() {
+        return 'Hello-id'
+      }
+    }
+    const app = tachijs({
+      controllers: [HomeController]
+    })
+
+    // When
+    const response = await request(app).get('/test/new')
+    const response_id = await request(app).get('/test/23')
+    // Then
+    expect(response).toMatchObject({
+      status: 200,
+      text: 'Hello'
+    })
+    expect(response_id).toMatchObject({
+      status: 200,
+      text: 'Hello-id'
+    })
+  })
 })
 
 describe('httpGet', () => {

--- a/src/specs/tachijs.spec.ts
+++ b/src/specs/tachijs.spec.ts
@@ -45,7 +45,7 @@ describe('tachijs', () => {
     class SecondController {
       @httpGet('/')
       index() {
-        return 'Hello'
+        return 'Hello Second'
       }
     }
     const app = tachijs({

--- a/src/specs/tachijs.spec.ts
+++ b/src/specs/tachijs.spec.ts
@@ -32,6 +32,36 @@ describe('tachijs', () => {
     })
   })
 
+  it('registers controllers from top to bottom', async () => {
+    // Given
+    @controller('/')
+    class HomeController {
+      @httpGet('/')
+      index() {
+        return 'Hello'
+      }
+    }
+    @controller('/')
+    class SecondController {
+      @httpGet('/')
+      index() {
+        return 'Hello'
+      }
+    }
+    const app = tachijs({
+      controllers: [HomeController, SecondController]
+    })
+
+    // When
+    const response = await request(app).get('/')
+
+    // Then
+    expect(response).toMatchObject({
+      status: 200,
+      text: 'Hello'
+    })
+  })
+
   it('throws an error if there is an invalid controller', () => {
     // Given
     class HomeController {


### PR DESCRIPTION
### Before

Httpmethods were registered from bottom to top. 
Hence the exact http methods match had to be put at the end of the routes with parameters.

### After 

Mimicking Express' default behavior, the httpmethods are registered from top to bottom inside of a controller.

Tests for the registration order have been added for both controllers and httpmethods.